### PR TITLE
Convert from ZkUtils to KafkaZkClient

### DIFF
--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseMetricsReporter.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseMetricsReporter.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 
 import io.confluent.support.metrics.common.Collector;
 import io.confluent.support.metrics.common.kafka.KafkaUtilities;
-import io.confluent.support.metrics.common.kafka.ZkUtilsProvider;
+import io.confluent.support.metrics.common.kafka.ZkClientProvider;
 import io.confluent.support.metrics.serde.AvroSerializer;
 import io.confluent.support.metrics.submitters.ConfluentSubmitter;
 import io.confluent.support.metrics.submitters.KafkaSubmitter;
@@ -118,7 +118,7 @@ public abstract class BaseMetricsReporter implements Runnable {
     supportTopic = supportConfig.getKafkaTopic();
 
     if (!supportTopic.isEmpty()) {
-      kafkaSubmitter = new KafkaSubmitter(zkUtilsProvider(), supportTopic);
+      kafkaSubmitter = new KafkaSubmitter(zkClientProvider(), supportTopic);
     } else {
       kafkaSubmitter = null;
     }
@@ -140,7 +140,7 @@ public abstract class BaseMetricsReporter implements Runnable {
     }
   }
 
-  protected abstract ZkUtilsProvider zkUtilsProvider();
+  protected abstract ZkClientProvider zkClientProvider();
 
   protected abstract Collector metricsCollector();
 
@@ -245,7 +245,7 @@ public abstract class BaseMetricsReporter implements Runnable {
       if (sendToKafkaEnabled() && encodedMetricsRecord != null) {
         // attempt to create the topic. If failures occur, try again in the next round, however
         // the current batch of metrics will be lost.
-        if (kafkaUtilities.createAndVerifyTopic(zkUtilsProvider().zkUtils(), supportTopic,
+        if (kafkaUtilities.createAndVerifyTopic(zkClientProvider().zkClient(), supportTopic,
             SUPPORT_TOPIC_PARTITIONS,
                                                 SUPPORT_TOPIC_REPLICATION, RETENTION_MS
         )) {

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseMetricsReporter.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseMetricsReporter.java
@@ -246,8 +246,7 @@ public abstract class BaseMetricsReporter implements Runnable {
         // attempt to create the topic. If failures occur, try again in the next round, however
         // the current batch of metrics will be lost.
         if (kafkaUtilities.createAndVerifyTopic(zkClientProvider().zkClient(), supportTopic,
-            SUPPORT_TOPIC_PARTITIONS,
-                                                SUPPORT_TOPIC_REPLICATION, RETENTION_MS
+            SUPPORT_TOPIC_PARTITIONS, SUPPORT_TOPIC_REPLICATION, RETENTION_MS
         )) {
           kafkaSubmitter.submit(encodedMetricsRecord);
         }

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/KafkaUtilities.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/KafkaUtilities.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 
@@ -71,9 +72,7 @@ public class KafkaUtilities {
    * @throws IllegalArgumentException if zkClient is null
    */
   public long getNumTopics(KafkaZkClient zkClient) {
-    if (zkClient == null) {
-      throw new IllegalArgumentException("zkClient must not be null");
-    }
+    Objects.requireNonNull(zkClient, "zkClient must not be null");
 
     try {
       Seq<String> topics = zkClient.getAllTopicsInCluster();
@@ -93,9 +92,8 @@ public class KafkaUtilities {
    *     errors.  Note that only servers with PLAINTEXT ports will be returned.
    */
   public List<String> getBootstrapServers(KafkaZkClient zkClient, int maxNumServers) {
-    if (zkClient == null) {
-      throw new IllegalArgumentException("zkClient must not be null");
-    }
+    Objects.requireNonNull(zkClient, "zkClient must not be null");
+
     if (maxNumServers < 1) {
       throw new IllegalArgumentException("maximum number of requested servers must be >= 1");
     }
@@ -138,9 +136,8 @@ public class KafkaUtilities {
       int replication,
       long retentionMs
   ) {
-    if (zkClient == null) {
-      throw new IllegalArgumentException("zkClient must not be null");
-    }
+    Objects.requireNonNull(zkClient, "zkClient must not be null");
+
     if (topic == null || topic.isEmpty()) {
       throw new IllegalArgumentException("topic must not be null or empty");
     }
@@ -221,10 +218,8 @@ public class KafkaUtilities {
       int expPartitions,
       int expReplication
   ) {
+    Objects.requireNonNull(zkClient, "zkClient must not be null");
 
-    if (zkClient == null) {
-      throw new IllegalArgumentException("zkClient must not be null");
-    }
     if (topic == null || topic.isEmpty()) {
       throw new IllegalArgumentException("topic must not be null or empty");
     }

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/KafkaUtilities.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/KafkaUtilities.java
@@ -14,30 +14,28 @@
 
 package io.confluent.support.metrics.common.kafka;
 
+import kafka.cluster.EndPoint;
+import kafka.zk.AdminZkClient;
+import kafka.zk.KafkaZkClient;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
 import kafka.admin.AdminOperationException;
-import kafka.admin.AdminUtils;
 import kafka.admin.RackAwareMode.Disabled$;
-import kafka.client.ClientUtils$;
 import kafka.cluster.Broker;
-import kafka.cluster.BrokerEndPoint;
-import kafka.common.BrokerEndPointNotAvailableException;
 import kafka.log.LogConfig;
 import kafka.server.BrokerShuttingDown;
 import kafka.server.KafkaServer;
 import kafka.server.PendingControlledShutdown;
 import kafka.server.RunningAsBroker;
-import kafka.utils.ZkUtils;
-import scala.collection.Iterator;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
 
@@ -70,15 +68,15 @@ public class KafkaUtilities {
    * Get the total number of topics in the cluster by querying ZooKeeper.
    *
    * @return The total number of topics in the cluster, or -1 if there was an error.
-   * @throws IllegalArgumentException if zkUtils is null
+   * @throws IllegalArgumentException if zkClient is null
    */
-  public long getNumTopics(ZkUtils zkUtils) {
-    if (zkUtils == null) {
-      throw new IllegalArgumentException("zkUtils must not be null");
+  public long getNumTopics(KafkaZkClient zkClient) {
+    if (zkClient == null) {
+      throw new IllegalArgumentException("zkClient must not be null");
     }
 
     try {
-      Seq<String> topics = zkUtils.getAllTopics();
+      Seq<String> topics = zkClient.getAllTopicsInCluster();
       return topics.length();
     } catch (Exception e) {
       log.error("Could not retrieve number of topics from ZooKeeper: {}", e.getMessage());
@@ -94,32 +92,31 @@ public class KafkaUtilities {
    * @return A list of bootstrap servers, or an empty list if there are none or if there were
    *     errors.  Note that only servers with PLAINTEXT ports will be returned.
    */
-  public List<String> getBootstrapServers(ZkUtils zkUtils, int maxNumServers) {
-    if (zkUtils == null) {
-      throw new IllegalArgumentException("zkUtils must not be null");
+  public List<String> getBootstrapServers(KafkaZkClient zkClient, int maxNumServers) {
+    if (zkClient == null) {
+      throw new IllegalArgumentException("zkClient must not be null");
     }
     if (maxNumServers < 1) {
       throw new IllegalArgumentException("maximum number of requested servers must be >= 1");
     }
 
     // Note that we only support PLAINTEXT ports for this version
-    Seq<BrokerEndPoint> brokerList = ClientUtils$.MODULE$.getPlaintextBrokerEndPoints(zkUtils);
-    if (brokerList == null || brokerList.isEmpty()) {
-      return new ArrayList<>();
+    List<Broker> brokers = JavaConversions.seqAsJavaList(zkClient.getAllBrokersInCluster());
+    if (brokers == null) {
+      return Collections.emptyList();
     } else {
-      int actualServers = Math.min(maxNumServers, brokerList.size());
       List<String> bootstrapServers = new ArrayList<>();
-      Iterator<BrokerEndPoint> it = brokerList.iterator();
-      int i = 0;
-      while (it.hasNext() && i < actualServers) {
-        BrokerEndPoint brokerEndPoint = it.next();
-        try {
-          bootstrapServers.add(brokerEndPoint.connectionString());
-          i++;
-        } catch (BrokerEndPointNotAvailableException e) {
-          // try next one
+      for (Broker broker : brokers) {
+        for (EndPoint endPoint : JavaConversions.seqAsJavaList(broker.endPoints())) {
+          if (endPoint.listenerName().value().equals("PLAINTEXT")) {
+            bootstrapServers.add(endPoint.connectionString());
+            if (bootstrapServers.size() == maxNumServers) {
+              break;
+            }
+          }
         }
       }
+
       return bootstrapServers;
     }
   }
@@ -135,14 +132,14 @@ public class KafkaUtilities {
    *     partitions have dropped to unacceptable levels.
    */
   public boolean createAndVerifyTopic(
-      ZkUtils zkUtils,
+      KafkaZkClient zkClient,
       String topic,
       int partitions,
       int replication,
       long retentionMs
   ) {
-    if (zkUtils == null) {
-      throw new IllegalArgumentException("zkUtils must not be null");
+    if (zkClient == null) {
+      throw new IllegalArgumentException("zkClient must not be null");
     }
     if (topic == null || topic.isEmpty()) {
       throw new IllegalArgumentException("topic must not be null or empty");
@@ -159,13 +156,13 @@ public class KafkaUtilities {
 
     boolean topicCreated = true;
     try {
-      if (AdminUtils.topicExists(zkUtils, topic)) {
+      if (zkClient.topicExists(topic)) {
         return (
-            verifySupportTopic(zkUtils, topic, partitions, replication)
+            verifySupportTopic(zkClient, topic, partitions, replication)
             != VerifyTopicState.Inadequate
           );
       }
-      Seq<Broker> brokerList = zkUtils.getAllBrokersInCluster();
+      Seq<Broker> brokerList = zkClient.getAllBrokersInCluster();
       int actualReplication = Math.min(replication, brokerList.size());
       if (actualReplication < replication) {
         log.warn(
@@ -187,8 +184,8 @@ public class KafkaUtilities {
       log.info("Attempting to create topic {} with {} replicas, assuming {} total brokers",
                topic, actualReplication, brokerList.size()
       );
-      AdminUtils.createTopic(
-          zkUtils,
+      AdminZkClient adminClient = new AdminZkClient(zkClient);
+      adminClient.createTopic(
           topic,
           partitions,
           actualReplication,
@@ -219,14 +216,14 @@ public class KafkaUtilities {
    * @return an enum describing the topic state
    */
   public VerifyTopicState verifySupportTopic(
-      ZkUtils zkUtils,
+      KafkaZkClient zkClient,
       String topic,
       int expPartitions,
       int expReplication
   ) {
 
-    if (zkUtils == null) {
-      throw new IllegalArgumentException("zkUtils must not be null");
+    if (zkClient == null) {
+      throw new IllegalArgumentException("zkClient must not be null");
     }
     if (topic == null || topic.isEmpty()) {
       throw new IllegalArgumentException("topic must not be null or empty");
@@ -242,12 +239,9 @@ public class KafkaUtilities {
     try {
       Set<String> topics = new HashSet<>();
       topics.add(topic);
-      scala.Option<scala.collection.Map<Object, Seq<Object>>> partitionAssignmentOption = zkUtils
-          .getPartitionAssignmentForTopics(
-              JavaConversions
-                  .asScalaSet(topics)
-                  .toSeq()
-          ).get(topic);
+      scala.Option<scala.collection.immutable.Map<Object, Seq<Object>>> partitionAssignmentOption =
+          zkClient.getPartitionAssignmentForTopics(
+              JavaConversions.asScalaSet(topics).<String>toSet()).get(topic);
       if (!partitionAssignmentOption.isEmpty()) {
         scala.collection.Map partitionAssignment = partitionAssignmentOption.get();
         int actualNumPartitions = partitionAssignment.size();

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/ZkClientProvider.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/ZkClientProvider.java
@@ -16,8 +16,8 @@
 
 package io.confluent.support.metrics.common.kafka;
 
-import kafka.utils.ZkUtils;
+import kafka.zk.KafkaZkClient;
 
-public interface ZkUtilsProvider {
-  ZkUtils zkUtils();
+public interface ZkClientProvider {
+  KafkaZkClient zkClient();
 }

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/ZkClientProvider.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/ZkClientProvider.java
@@ -19,5 +19,12 @@ package io.confluent.support.metrics.common.kafka;
 import kafka.zk.KafkaZkClient;
 
 public interface ZkClientProvider {
+
+  /**
+   * Return a KafkaZkClient instance.
+   *
+   * The caller is not responsible for closing the returned instance. As such, implementations must return a cached
+   * instance that is closed via its own lifecycle operations (e.g. when the broker is shutdown).
+   */
   KafkaZkClient zkClient();
 }

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/ZkClientProvider.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/ZkClientProvider.java
@@ -23,8 +23,9 @@ public interface ZkClientProvider {
   /**
    * Return a KafkaZkClient instance.
    *
-   * The caller is not responsible for closing the returned instance. As such, implementations must return a cached
-   * instance that is closed via its own lifecycle operations (e.g. when the broker is shutdown).
+   * <p>The caller is not responsible for closing the returned instance. As such, implementations
+   * must return a cached instance that is closed via its own lifecycle operations (e.g. when the
+   * broker is shutdown).
    */
   KafkaZkClient zkClient();
 }

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/submitters/KafkaSubmitter.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/submitters/KafkaSubmitter.java
@@ -114,8 +114,7 @@ public class KafkaSubmitter implements Submitter {
       zkClient = zkClientProvider.zkClient();
     }
     List<String> bootstrapServerList = new KafkaUtilities().getBootstrapServers(
-            zkClient,
-        BOOTSTRAP_SERVERS
+        zkClient, BOOTSTRAP_SERVERS
     );
     String[] bootstrapServers = bootstrapServerList.toArray(new String[bootstrapServerList.size()]);
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, StringUtils.join(bootstrapServers, ","));

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/submitters/KafkaSubmitter.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/submitters/KafkaSubmitter.java
@@ -14,6 +14,7 @@
 
 package io.confluent.support.metrics.submitters;
 
+import kafka.zk.KafkaZkClient;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -29,8 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import io.confluent.support.metrics.common.kafka.KafkaUtilities;
-import io.confluent.support.metrics.common.kafka.ZkUtilsProvider;
-import kafka.utils.ZkUtils;
+import io.confluent.support.metrics.common.kafka.ZkClientProvider;
 
 public class KafkaSubmitter implements Submitter {
 
@@ -39,8 +39,8 @@ public class KafkaSubmitter implements Submitter {
   private static final Integer requiredNumAcks = 1;
   private static final int maxBlockMs = 10 * 1000;
   private final String topic;
-  private final ZkUtilsProvider zkUtilsProvider;
-  private ZkUtils zkUtils;
+  private final ZkClientProvider zkClientProvider;
+  private KafkaZkClient zkClient;
 
   /**
    * Ideal number of bootstrap servers for the kafka producer.
@@ -50,11 +50,11 @@ public class KafkaSubmitter implements Submitter {
   /**
    * @param topic The Kafka topic to which data is being sent.
    */
-  public KafkaSubmitter(ZkUtilsProvider zkUtilsProvider, String topic) {
-    if (zkUtilsProvider == null) {
-      throw new IllegalArgumentException("must specify zkUtils provider");
+  public KafkaSubmitter(ZkClientProvider zkClientProvider, String topic) {
+    if (zkClientProvider == null) {
+      throw new IllegalArgumentException("must specify zkClientProvider");
     } else {
-      this.zkUtilsProvider = zkUtilsProvider;
+      this.zkClientProvider = zkClientProvider;
     }
 
     if (topic == null || topic.isEmpty()) {
@@ -110,11 +110,11 @@ public class KafkaSubmitter implements Submitter {
 
   private Producer<byte[], byte[]> createProducer() {
     Properties props = new Properties();
-    if (zkUtils == null) {
-      zkUtils = zkUtilsProvider.zkUtils();
+    if (zkClient == null) {
+      zkClient = zkClientProvider.zkClient();
     }
     List<String> bootstrapServerList = new KafkaUtilities().getBootstrapServers(
-        zkUtils,
+            zkClient,
         BOOTSTRAP_SERVERS
     );
     String[] bootstrapServers = bootstrapServerList.toArray(new String[bootstrapServerList.size()]);

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/common/kafka/KafkaUtilitiesTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/common/kafka/KafkaUtilitiesTest.java
@@ -53,7 +53,7 @@ public class KafkaUtilitiesTest {
     try {
       kUtil.getNumTopics(null);
       fail("IllegalArgumentException expected because zkClient is null");
-    } catch (IllegalArgumentException e) {
+    } catch (NullPointerException e) {
       // ignore
     }
   }
@@ -104,7 +104,7 @@ public class KafkaUtilitiesTest {
     try {
       kUtil.getBootstrapServers(null, anyMaxNumServers);
       fail("IllegalArgumentException expected because zkClient is null");
-    } catch (IllegalArgumentException e) {
+    } catch (NullPointerException e) {
       // ignore
     }
   }
@@ -145,7 +145,7 @@ public class KafkaUtilitiesTest {
     try {
       kUtil.createAndVerifyTopic(null, anyTopic, anyPartitions, anyReplication, anyRetentionMs);
       fail("IllegalArgumentException expected because zkClient is null");
-    } catch (IllegalArgumentException e) {
+    } catch (NullPointerException e) {
       // ignore
     }
   }
@@ -235,7 +235,7 @@ public class KafkaUtilitiesTest {
     try {
       kUtil.verifySupportTopic(null, anyTopic, anyPartitions, anyReplication);
       fail("IllegalArgumentException expected because zkClient is null");
-    } catch (IllegalArgumentException e) {
+    } catch (NullPointerException e) {
       // ignore
     }
   }

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/common/kafka/KafkaUtilitiesTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/common/kafka/KafkaUtilitiesTest.java
@@ -13,6 +13,7 @@
  */
 package io.confluent.support.metrics.common.kafka;
 
+import kafka.zk.KafkaZkClient;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -21,7 +22,6 @@ import java.util.Random;
 
 import kafka.cluster.Broker;
 import kafka.server.KafkaServer;
-import kafka.utils.ZkUtils;
 import scala.collection.JavaConversions;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
  */
 public class KafkaUtilitiesTest {
 
-  private static final ZkUtils mockZkUtils = mock(ZkUtils.class);
+  private static final KafkaZkClient mockZkClient = mock(KafkaZkClient.class);
   private static final int anyMaxNumServers = 2;
   private static final String anyTopic = "valueNotRelevant";
   private static final int anyPartitions = 1;
@@ -45,14 +45,14 @@ public class KafkaUtilitiesTest {
   private static final String[] exampleTopics = {"__confluent.support.metrics", "anyTopic", "basketball"};
 
   @Test
-  public void getNumTopicsThrowsIAEWhenZkUtilsIsNull() {
+  public void getNumTopicsThrowsIAEWhenKafkaZkClientIsNull() {
     // Given
     KafkaUtilities kUtil = new KafkaUtilities();
 
     // When/Then
     try {
       kUtil.getNumTopics(null);
-      fail("IllegalArgumentException expected because zkUtils is null");
+      fail("IllegalArgumentException expected because zkClient is null");
     } catch (IllegalArgumentException e) {
       // ignore
     }
@@ -62,48 +62,48 @@ public class KafkaUtilitiesTest {
   public void getNumTopicsReturnsMinusOneOnError() {
     // Given
     KafkaUtilities kUtil = new KafkaUtilities();
-    ZkUtils zkUtils = mock(ZkUtils.class);
-    when(zkUtils.getAllTopics()).thenThrow(new RuntimeException("exception intentionally thrown by test"));
+    KafkaZkClient zkClient = mock(KafkaZkClient.class);
+    when(zkClient.getAllTopicsInCluster()).thenThrow(new RuntimeException("exception intentionally thrown by test"));
 
     // When/Then
-    assertThat(kUtil.getNumTopics(zkUtils)).isEqualTo(-1L);
+    assertThat(kUtil.getNumTopics(zkClient)).isEqualTo(-1L);
   }
 
   @Test
   public void getNumTopicsReturnsZeroWhenThereAreNoTopics() {
     // Given
     KafkaUtilities kUtil = new KafkaUtilities();
-    ZkUtils zkUtils = mock(ZkUtils.class);
+    KafkaZkClient zkClient = mock(KafkaZkClient.class);
     List<String> zeroTopics = new ArrayList<>();
-    when(zkUtils.getAllTopics()).thenReturn(JavaConversions.asScalaBuffer(zeroTopics).toList());
+    when(zkClient.getAllTopicsInCluster()).thenReturn(JavaConversions.asScalaBuffer(zeroTopics).toList());
 
     // When/Then
-    assertThat(kUtil.getNumTopics(zkUtils)).isEqualTo(0L);
+    assertThat(kUtil.getNumTopics(zkClient)).isEqualTo(0L);
   }
 
   @Test
   public void getNumTopicsReturnsCorrectNumber() {
     // Given
     KafkaUtilities kUtil = new KafkaUtilities();
-    ZkUtils zkUtils = mock(ZkUtils.class);
+    KafkaZkClient zkClient = mock(KafkaZkClient.class);
     List<String> topics = new ArrayList<>();
     topics.add("topic1");
     topics.add("topic2");
-    when(zkUtils.getAllTopics()).thenReturn(JavaConversions.asScalaBuffer(topics).toList());
+    when(zkClient.getAllTopicsInCluster()).thenReturn(JavaConversions.asScalaBuffer(topics).toList());
 
     // When/Then
-    assertThat(kUtil.getNumTopics(zkUtils)).isEqualTo(topics.size());
+    assertThat(kUtil.getNumTopics(zkClient)).isEqualTo(topics.size());
   }
 
   @Test
-  public void getBootstrapServersThrowsIAEWhenZkUtilsIsNull() {
+  public void getBootstrapServersThrowsIAEWhenKafkaZkClientIsNull() {
     // Given
     KafkaUtilities kUtil = new KafkaUtilities();
 
     // When/Then
     try {
       kUtil.getBootstrapServers(null, anyMaxNumServers);
-      fail("IllegalArgumentException expected because zkUtils is null");
+      fail("IllegalArgumentException expected because zkClient is null");
     } catch (IllegalArgumentException e) {
       // ignore
     }
@@ -117,7 +117,7 @@ public class KafkaUtilitiesTest {
 
     // When/Then
     try {
-      kUtil.getBootstrapServers(mockZkUtils, zeroMaxNumServers);
+      kUtil.getBootstrapServers(mockZkClient, zeroMaxNumServers);
       fail("IllegalArgumentException expected because max number of servers is zero");
     } catch (IllegalArgumentException e) {
       // ignore
@@ -128,23 +128,23 @@ public class KafkaUtilitiesTest {
   public void getBootstrapServersReturnsEmptyListWhenThereAreNoLiveBrokers() {
     // Given
     KafkaUtilities kUtil = new KafkaUtilities();
-    ZkUtils zkUtils = mock(ZkUtils.class);
+    KafkaZkClient zkClient = mock(KafkaZkClient.class);
     List<Broker> empty = new ArrayList<>();
-    when(zkUtils.getAllBrokersInCluster()).thenReturn(JavaConversions.asScalaBuffer(empty).toList());
+    when(zkClient.getAllBrokersInCluster()).thenReturn(JavaConversions.asScalaBuffer(empty).toList());
 
     // When/Then
-    assertThat(kUtil.getBootstrapServers(zkUtils, anyMaxNumServers)).isEmpty();
+    assertThat(kUtil.getBootstrapServers(zkClient, anyMaxNumServers)).isEmpty();
   }
 
   @Test
-  public void createTopicThrowsIAEWhenZkUtilsIsNull() {
+  public void createTopicThrowsIAEWhenKafkaZkClientIsNull() {
     // Given
     KafkaUtilities kUtil = new KafkaUtilities();
 
     // When/Then
     try {
       kUtil.createAndVerifyTopic(null, anyTopic, anyPartitions, anyReplication, anyRetentionMs);
-      fail("IllegalArgumentException expected because zkUtils is null");
+      fail("IllegalArgumentException expected because zkClient is null");
     } catch (IllegalArgumentException e) {
       // ignore
     }
@@ -158,7 +158,7 @@ public class KafkaUtilitiesTest {
 
     // When/Then
     try {
-      kUtil.createAndVerifyTopic(mockZkUtils, nullTopic, anyPartitions, anyReplication, anyRetentionMs);
+      kUtil.createAndVerifyTopic(mockZkClient, nullTopic, anyPartitions, anyReplication, anyRetentionMs);
       fail("IllegalArgumentException expected because topic is null");
     } catch (IllegalArgumentException e) {
       // ignore
@@ -173,7 +173,7 @@ public class KafkaUtilitiesTest {
 
     // When/Then
     try {
-      kUtil.createAndVerifyTopic(mockZkUtils, emptyTopic, anyPartitions, anyReplication, anyRetentionMs);
+      kUtil.createAndVerifyTopic(mockZkClient, emptyTopic, anyPartitions, anyReplication, anyRetentionMs);
       fail("IllegalArgumentException expected because topic is empty");
     } catch (IllegalArgumentException e) {
       // ignore
@@ -188,7 +188,7 @@ public class KafkaUtilitiesTest {
 
     // When/Then
     try {
-      kUtil.createAndVerifyTopic(mockZkUtils, anyTopic, zeroPartitions, anyReplication, anyRetentionMs);
+      kUtil.createAndVerifyTopic(mockZkClient, anyTopic, zeroPartitions, anyReplication, anyRetentionMs);
       fail("IllegalArgumentException expected because number of partitions is zero");
     } catch (IllegalArgumentException e) {
       // ignore
@@ -203,7 +203,7 @@ public class KafkaUtilitiesTest {
 
     // When/Then
     try {
-      kUtil.createAndVerifyTopic(mockZkUtils, anyTopic, anyPartitions, zeroReplication, anyRetentionMs);
+      kUtil.createAndVerifyTopic(mockZkClient, anyTopic, anyPartitions, zeroReplication, anyRetentionMs);
       fail("IllegalArgumentException expected because replication factor is zero");
     } catch (IllegalArgumentException e) {
       // ignore
@@ -218,7 +218,7 @@ public class KafkaUtilitiesTest {
 
     // When/Then
     try {
-      kUtil.createAndVerifyTopic(mockZkUtils, anyTopic, anyPartitions, anyReplication, zeroRetentionMs);
+      kUtil.createAndVerifyTopic(mockZkClient, anyTopic, anyPartitions, anyReplication, zeroRetentionMs);
       fail("IllegalArgumentException expected because retention.ms is zero");
     } catch (IllegalArgumentException e) {
       // ignore
@@ -227,14 +227,14 @@ public class KafkaUtilitiesTest {
 
 
   @Test
-  public void verifySupportTopicThrowsIAEWhenZkUtilsIsNull() {
+  public void verifySupportTopicThrowsIAEWhenKafkaZkClientIsNull() {
     // Given
     KafkaUtilities kUtil = new KafkaUtilities();
 
     // When/Then
     try {
       kUtil.verifySupportTopic(null, anyTopic, anyPartitions, anyReplication);
-      fail("IllegalArgumentException expected because zkUtils is null");
+      fail("IllegalArgumentException expected because zkClient is null");
     } catch (IllegalArgumentException e) {
       // ignore
     }
@@ -249,7 +249,7 @@ public class KafkaUtilitiesTest {
 
     // When/Then
     try {
-      kUtil.verifySupportTopic(mockZkUtils, nullTopic, anyPartitions, anyReplication);
+      kUtil.verifySupportTopic(mockZkClient, nullTopic, anyPartitions, anyReplication);
       fail("IllegalArgumentException expected because topic is null");
     } catch (IllegalArgumentException e) {
       // ignore
@@ -264,7 +264,7 @@ public class KafkaUtilitiesTest {
 
     // When/Then
     try {
-      kUtil.verifySupportTopic(mockZkUtils, emptyTopic, anyPartitions, anyReplication);
+      kUtil.verifySupportTopic(mockZkClient, emptyTopic, anyPartitions, anyReplication);
       fail("IllegalArgumentException expected because topic is empty");
     } catch (IllegalArgumentException e) {
       // ignore
@@ -279,7 +279,7 @@ public class KafkaUtilitiesTest {
 
     // When/Then
     try {
-      kUtil.verifySupportTopic(mockZkUtils, anyTopic, zeroPartitions, anyReplication);
+      kUtil.verifySupportTopic(mockZkClient, anyTopic, zeroPartitions, anyReplication);
       fail("IllegalArgumentException expected because number of partitions is zero");
     } catch (IllegalArgumentException e) {
       // ignore
@@ -294,7 +294,7 @@ public class KafkaUtilitiesTest {
 
     // When/Then
     try {
-      kUtil.verifySupportTopic(mockZkUtils, anyTopic, anyPartitions, zeroReplication);
+      kUtil.verifySupportTopic(mockZkClient, anyTopic, anyPartitions, zeroReplication);
       fail("IllegalArgumentException expected because replication factor is zero");
     } catch (IllegalArgumentException e) {
       // ignore
@@ -311,17 +311,19 @@ public class KafkaUtilitiesTest {
     int replication = numBrokers + 1;
     cluster.startCluster(numBrokers);
     KafkaServer broker = cluster.getBroker(0);
+    KafkaZkClient zkClient = broker.zkClient();
 
     // When/Then
     for (String topic : exampleTopics) {
-      assertThat(kUtil.createAndVerifyTopic(broker.zkUtils(), topic, partitions, replication, oneYearRetention)).isTrue();
+      assertThat(kUtil.createAndVerifyTopic(zkClient, topic, partitions, replication, oneYearRetention)).isTrue();
       // Only one broker is up, so the actual number of replicas will be only 1.
-      assertThat(kUtil.verifySupportTopic(broker.zkUtils(), topic, partitions, replication)).isEqualTo(KafkaUtilities.VerifyTopicState.Less);
+      assertThat(kUtil.verifySupportTopic(zkClient, topic, partitions, replication)).isEqualTo(KafkaUtilities.VerifyTopicState.Less);
     }
-    assertThat(kUtil.getNumTopics(broker.zkUtils())).isEqualTo(exampleTopics.length);
+    assertThat(kUtil.getNumTopics(zkClient)).isEqualTo(exampleTopics.length);
 
     // Cleanup
     cluster.stopCluster();
+    zkClient.close();
   }
 
 
@@ -335,14 +337,15 @@ public class KafkaUtilitiesTest {
     int replication = numBrokers + 1;
     cluster.startCluster(numBrokers);
     KafkaServer broker = cluster.getBroker(0);
+    KafkaZkClient zkClient = broker.zkClient();
 
     // When/Then
     for (String topic : exampleTopics) {
-      assertThat(kUtil.createAndVerifyTopic(broker.zkUtils(), topic, partitions, replication, oneYearRetention)).isTrue();
-      assertThat(kUtil.createAndVerifyTopic(broker.zkUtils(), topic, partitions, replication, oneYearRetention)).isTrue();
-      assertThat(kUtil.verifySupportTopic(broker.zkUtils(), topic, partitions, replication)).isEqualTo(KafkaUtilities.VerifyTopicState.Less);
+      assertThat(kUtil.createAndVerifyTopic(zkClient, topic, partitions, replication, oneYearRetention)).isTrue();
+      assertThat(kUtil.createAndVerifyTopic(zkClient, topic, partitions, replication, oneYearRetention)).isTrue();
+      assertThat(kUtil.verifySupportTopic(zkClient, topic, partitions, replication)).isEqualTo(KafkaUtilities.VerifyTopicState.Less);
     }
-    assertThat(kUtil.getNumTopics(broker.zkUtils())).isEqualTo(exampleTopics.length);
+    assertThat(kUtil.getNumTopics(zkClient)).isEqualTo(exampleTopics.length);
 
     // Cleanup
     cluster.stopCluster();
@@ -356,11 +359,11 @@ public class KafkaUtilitiesTest {
     EmbeddedKafkaCluster cluster = new EmbeddedKafkaCluster();
     cluster.startCluster(1);
     KafkaServer broker = cluster.getBroker(0);
-    ZkUtils defunctZkUtils = broker.zkUtils();
+    KafkaZkClient defunctZkClient = broker.zkClient();
     cluster.stopCluster();
 
     // When/Then
-    assertThat(kUtil.createAndVerifyTopic(defunctZkUtils, anyTopic, anyPartitions, anyReplication, anyRetentionMs)).isFalse();
+    assertThat(kUtil.createAndVerifyTopic(defunctZkClient, anyTopic, anyPartitions, anyReplication, anyRetentionMs)).isFalse();
   }
 
   @Test
@@ -371,15 +374,15 @@ public class KafkaUtilitiesTest {
     int numBrokers = 3;
     cluster.startCluster(numBrokers);
     KafkaServer broker = cluster.getBroker(0);
-    ZkUtils zkUtils = broker.zkUtils();
+    KafkaZkClient zkClient = broker.zkClient();
     Random random = new Random();
     int replication = numBrokers;
 
     // When/Then
     for (String topic : exampleTopics) {
       int morePartitionsThanBrokers = random.nextInt(10) + numBrokers + 1;
-      assertThat(kUtil.createAndVerifyTopic(zkUtils, topic, morePartitionsThanBrokers, replication, oneYearRetention)).isTrue();
-      assertThat(kUtil.verifySupportTopic(zkUtils, topic, morePartitionsThanBrokers, replication)).isEqualTo(KafkaUtilities.VerifyTopicState.Exactly);
+      assertThat(kUtil.createAndVerifyTopic(zkClient, topic, morePartitionsThanBrokers, replication, oneYearRetention)).isTrue();
+      assertThat(kUtil.verifySupportTopic(zkClient, topic, morePartitionsThanBrokers, replication)).isEqualTo(KafkaUtilities.VerifyTopicState.Exactly);
     }
 
     // Cleanup

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/submitters/KafkaSubmitterTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/submitters/KafkaSubmitterTest.java
@@ -18,8 +18,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import io.confluent.support.metrics.common.kafka.ZkUtilsProvider;
-import kafka.utils.ZkUtils;
+import io.confluent.support.metrics.common.kafka.ZkClientProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -31,17 +30,17 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class KafkaSubmitterTest {
 
-  private static ZkUtilsProvider zkUtilsProvider;
+  private static ZkClientProvider zkClientProvider;
 
   @BeforeClass
   public static void startCluster() {
-    zkUtilsProvider = mock(ZkUtilsProvider.class);
+    zkClientProvider = mock(ZkClientProvider.class);
   }
 
   @Test
   public void testInvalidArgumentsForConstructorNullServer() {
     // Given
-    ZkUtilsProvider nullServer = null;
+    ZkClientProvider nullServer = null;
     String anyTopic = "valueNotRelevant";
 
     // When/Then
@@ -49,7 +48,7 @@ public class KafkaSubmitterTest {
       new KafkaSubmitter(nullServer, anyTopic);
       fail("IllegalArgumentException expected because server is null");
     } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("must specify zkUtils provider");
+      assertThat(e).hasMessage("must specify zkClientProvider");
     }
   }
 
@@ -61,7 +60,7 @@ public class KafkaSubmitterTest {
 
     // When/Then
     try {
-      new KafkaSubmitter(zkUtilsProvider, nullTopic);
+      new KafkaSubmitter(zkClientProvider, nullTopic);
       fail("IllegalArgumentException expected because topic is null");
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage("must specify topic");
@@ -75,7 +74,7 @@ public class KafkaSubmitterTest {
 
     // When/Then
     try {
-      new KafkaSubmitter(zkUtilsProvider, emptyTopic);
+      new KafkaSubmitter(zkClientProvider, emptyTopic);
       fail("IllegalArgumentException expected because topic is the empty string");
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage("must specify topic");
@@ -86,7 +85,7 @@ public class KafkaSubmitterTest {
   public void testSubmitIgnoresNullInput() {
     // Given
     String anyTopic = "valueNotRelevant";
-    KafkaSubmitter k = new KafkaSubmitter(zkUtilsProvider, anyTopic);
+    KafkaSubmitter k = new KafkaSubmitter(zkClientProvider, anyTopic);
     Producer<byte[], byte[]> producer = mock(Producer.class);
     byte[] nullData = null;
 
@@ -101,7 +100,7 @@ public class KafkaSubmitterTest {
   public void testSubmitIgnoresEmptyInput() {
     // Given
     String anyTopic = "valueNotRelevant";
-    KafkaSubmitter k = new KafkaSubmitter(zkUtilsProvider, anyTopic);
+    KafkaSubmitter k = new KafkaSubmitter(zkClientProvider, anyTopic);
     Producer<byte[], byte[]> producer = mock(Producer.class);
     byte[] emptyData = new byte[0];
 
@@ -116,7 +115,7 @@ public class KafkaSubmitterTest {
   public void testSubmit() {
     // Given
     String anyTopic = "valueNotRelevant";
-    KafkaSubmitter k = new KafkaSubmitter(zkUtilsProvider, anyTopic);
+    KafkaSubmitter k = new KafkaSubmitter(zkClientProvider, anyTopic);
     Producer<byte[], byte[]> producer = mock(Producer.class);
     byte[] anyData = "anyData".getBytes();
 


### PR DESCRIPTION
ZkUtils is no longer used by the Kafka broker.