### PR TITLE
PSM-54: provide PhoneHomeConfig to ensure unified endpoints

### DIFF
--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -34,9 +34,9 @@ public abstract class BaseSupportConfig {
   private static final Logger log = LoggerFactory.getLogger(BaseSupportConfig.class);
 
   static final String CONFLUENT_PHONE_HOME_ENDPOINT_BASE_SECURE =
-      "https://phone-home.confluent.io";
+      "https://version-check.confluent.io";
   static final String CONFLUENT_PHONE_HOME_ENDPOINT_BASE_INSECURE =
-      "http://phone-home.confluent.io";
+      "http://version-check.confluent.io";
   static final String CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_ANON = "anon";
   static final String CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_TEST = "test";
   static final String CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_CUSTOMER = "submit";

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -203,7 +203,7 @@ public abstract class BaseSupportConfig {
         setEndpointHTTPS(getEndpoint(true, customerId, endpointPath));
       }
     } else {
-      // TODO(apovzner) once all existing clients implement getURI, remove this code
+      // TODO(apovzner) once all existing clients provide endpointPath, remove this code
       // set the correct customer id/endpoint pair
       setEndpointsOldWay(customerId);
     }

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -252,7 +252,7 @@ public abstract class BaseSupportConfig {
   private String getEndpoint(boolean secure, String customerId, String endpointPath) {
     String base = secure ? CONFLUENT_PHONE_HOME_ENDPOINT_BASE_SECURE
                          : CONFLUENT_PHONE_HOME_ENDPOINT_BASE_INSECURE;
-    return String.join("/", base, endpointPath, getEndpointSuffix(customerId));
+    return base + "/" + endpointPath + "/" + getEndpointSuffix(customerId);
   }
 
   private String getEndpointSuffix(String customerId) {

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/PhoneHomeConfig.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/PhoneHomeConfig.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+/**
+ * Use this config for component-specific phone-home clients. It disables writing metrics to
+ * Kafka topic and ensures that non-test customer Ids are "anonymous", even if the client sets
+ * support topic and customer id in the config.
+ * TODO(apovzner) this class will probably be extended for standard phone-home libraries (the
+ * difference is a different URI format).
+ */
+public class PhoneHomeConfig extends BaseSupportConfig {
+
+  private static final Logger log = LoggerFactory.getLogger(PhoneHomeConfig.class);
+
+  private static final boolean CONFLUENT_SUPPORT_METRICS_TOPIC_ENABLED_DEFAULT = false;
+  private static final boolean CONFLUENT_SUPPORT_CUSTOMER_ID_ENABLED_DEFAULT = false;
+
+  /**
+   * Will make sure that writing to support metrics topic is disabled and there is no customer
+   * endpoint.
+   */
+  public PhoneHomeConfig(Properties originals, String componentId) {
+    this(originals, componentId,
+         CONFLUENT_SUPPORT_METRICS_TOPIC_ENABLED_DEFAULT,
+         CONFLUENT_SUPPORT_CUSTOMER_ID_ENABLED_DEFAULT);
+  }
+
+  private PhoneHomeConfig(Properties originals, String componentId,
+                          boolean supportMetricsTopicEnabled, boolean supportCustomerIdEnabled) {
+    super(setupProperties(originals, supportMetricsTopicEnabled, supportCustomerIdEnabled),
+          getEndpointPath(componentId));
+  }
+
+  private static Properties setupProperties(Properties originals,
+                                            boolean supportMetricsTopicEnabled,
+                                            boolean supportCustomerIdEnabled) {
+    if (!supportCustomerIdEnabled || !supportMetricsTopicEnabled) {
+      //disable publish to topic
+      if (originals == null) {
+        originals = new Properties();
+      }
+      if (!supportMetricsTopicEnabled) {
+        log.warn("Writing to metrics Kafka topic will be disabled");
+        originals.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "");
+      }
+      if (!supportCustomerIdEnabled) {
+        if (!isTestUser(getCustomerId(originals))) {
+          log.warn("Enforcing customer ID '{}'", CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
+          originals.setProperty(CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
+                                CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT);
+        }
+      }
+    }
+    return originals;
+  }
+
+
+  /**
+   * The resulting secure endpoint will be:
+   * BaseSupportConfig.CONFLUENT_PHONE_HOME_ENDPOINT_BASE_SECURE/getEndpointPath()/{anon|test}
+   * The resulting insecure endpoint will be:
+   * BaseSupportConfig.CONFLUENT_PHONE_HOME_ENDPOINT_BASE_INSECURE/getEndpointPath()/{anon|test}
+   */
+  private static String getEndpointPath(String componentId) {
+    return componentId;
+  }
+
+}

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
@@ -31,9 +31,9 @@ public class PhoneHomeConfigTest {
     BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
     assertEquals("", config.getKafkaTopic());
     assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, config.getCustomerId());
-    assertEquals("https://version-check.confluent.io/TestComponent/anon",
+    assertEquals("https://phone-home.confluent.io/TestComponent/anon",
                  config.getEndpointHTTPS());
-    assertEquals("http://version-check.confluent.io/TestComponent/anon",
+    assertEquals("http://phone-home.confluent.io/TestComponent/anon",
                  config.getEndpointHTTP());
   }
 
@@ -46,9 +46,9 @@ public class PhoneHomeConfigTest {
     BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
     assertEquals("", config.getKafkaTopic());
     assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT, config.getCustomerId());
-    assertEquals("https://version-check.confluent.io/TestComponent/test",
+    assertEquals("https://phone-home.confluent.io/TestComponent/test",
                  config.getEndpointHTTPS());
-    assertEquals("http://version-check.confluent.io/TestComponent/test",
+    assertEquals("http://phone-home.confluent.io/TestComponent/test",
                  config.getEndpointHTTP());
   }
 
@@ -60,7 +60,7 @@ public class PhoneHomeConfigTest {
 
     BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
     assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, config.getCustomerId());
-    assertEquals("https://version-check.confluent.io/TestComponent/anon",
+    assertEquals("https://phone-home.confluent.io/TestComponent/anon",
                  config.getEndpointHTTPS());
     assertEquals("",
                  config.getEndpointHTTP());

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class PhoneHomeConfigTest {
+
+  @Test
+  public void testProductionEndpoints() {
+    Properties overrideProps = new Properties();
+    overrideProps.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG, "c11");
+    overrideProps.getProperty(BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_TOPIC_CONFIG, "topic");
+
+    BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
+    assertEquals("", config.getKafkaTopic());
+    assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, config.getCustomerId());
+    assertEquals("https://version-check.confluent.io/TestComponent/anon",
+                 config.getEndpointHTTPS());
+    assertEquals("http://version-check.confluent.io/TestComponent/anon",
+                 config.getEndpointHTTP());
+  }
+
+  @Test
+  public void testTestEndpoints() {
+    Properties overrideProps = new Properties();
+    overrideProps.setProperty(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG,
+                              BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT);
+
+    BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
+    assertEquals("", config.getKafkaTopic());
+    assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT, config.getCustomerId());
+    assertEquals("https://version-check.confluent.io/TestComponent/test",
+                 config.getEndpointHTTPS());
+    assertEquals("http://version-check.confluent.io/TestComponent/test",
+                 config.getEndpointHTTP());
+  }
+
+  @Test
+  public void testInsecureEndpointDisabled() {
+    Properties overrideProps = new Properties();
+    overrideProps.setProperty(
+        BaseSupportConfig.CONFLUENT_SUPPORT_METRICS_ENDPOINT_INSECURE_ENABLE_CONFIG, "false");
+
+    BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
+    assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, config.getCustomerId());
+    assertEquals("https://version-check.confluent.io/TestComponent/anon",
+                 config.getEndpointHTTPS());
+    assertEquals("",
+                 config.getEndpointHTTP());
+  }
+
+}

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/PhoneHomeConfigTest.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.assertEquals;
 
 public class PhoneHomeConfigTest {
 
+  private static final String EXPECTED_SECURE_ENDPOINT = "https://version-check.confluent.io";
+  private static final String EXPECTED_INSECURE_ENDPOINT = "http://version-check.confluent.io";
+
   @Test
   public void testProductionEndpoints() {
     Properties overrideProps = new Properties();
@@ -31,9 +34,9 @@ public class PhoneHomeConfigTest {
     BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
     assertEquals("", config.getKafkaTopic());
     assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, config.getCustomerId());
-    assertEquals("https://phone-home.confluent.io/TestComponent/anon",
+    assertEquals(EXPECTED_SECURE_ENDPOINT + "/TestComponent/anon",
                  config.getEndpointHTTPS());
-    assertEquals("http://phone-home.confluent.io/TestComponent/anon",
+    assertEquals(EXPECTED_INSECURE_ENDPOINT + "/TestComponent/anon",
                  config.getEndpointHTTP());
   }
 
@@ -46,9 +49,9 @@ public class PhoneHomeConfigTest {
     BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
     assertEquals("", config.getKafkaTopic());
     assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT, config.getCustomerId());
-    assertEquals("https://phone-home.confluent.io/TestComponent/test",
+    assertEquals(EXPECTED_SECURE_ENDPOINT + "/TestComponent/test",
                  config.getEndpointHTTPS());
-    assertEquals("http://phone-home.confluent.io/TestComponent/test",
+    assertEquals(EXPECTED_INSECURE_ENDPOINT + "/TestComponent/test",
                  config.getEndpointHTTP());
   }
 
@@ -60,7 +63,7 @@ public class PhoneHomeConfigTest {
 
     BaseSupportConfig config = new PhoneHomeConfig(overrideProps, "TestComponent");
     assertEquals(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, config.getCustomerId());
-    assertEquals("https://phone-home.confluent.io/TestComponent/anon",
+    assertEquals(EXPECTED_SECURE_ENDPOINT + "/TestComponent/anon",
                  config.getEndpointHTTPS());
     assertEquals("",
                  config.getEndpointHTTP());


### PR DESCRIPTION
To ensure that we use unified endpoints for phone-home-clients (basically, in the form of https://phone-home.confluent.io/{componentId}/{option}), added PhoneHomeConfig to the client library. Also on a path to deprecate `getXXXEndpoint` in BaseSupportConfig, so that phone-home-clients do not try to provide their own endpoints.

UPDATE: actually still using version-check.confluent.io as base, which is used by KSQL and that's the only CNAME that currently points to our elastic beanstalk phone-home server. I somehow don't have permissions anymore to add new CNAMEs. Will request support, but for now lets use the endpoint that works. 

The expectation is that phone-home clients should use PhoneHomeConfig:
**C3 phone-home**: Do not implement config class derived from `BaseSupportConfig` as currently done in KSQL Beacon. Use `new PhoneHomeConfig(your_properties, "C3")`, or any other name for Control Center (maybe "ConfluentControlCenter").
**KSQL Beacon**: I will remove `KsqlVersionCheckerConfig` in a separate PR, and instead will use PhoneHomeConfig (`new PhoneHomeConfig(ksqlProperties, "ksql")`)

Note that `BaseSupportConfig` is currently used by ProactiveSupport (`KafkaSupportConfig`) and KSQL (`KsqlVersionCheckerConfig`), which are in different repos. So, to make sure I don't break any builds, this PR adds new way of using BaseSupportConfig while maintaining old way. 
The plan after this PR:
1) PR in KSQL to use 'PhoneHomeConfig` instead of `KsqlVersionCheckerConfig`
2) PR in support-metrics-client to make KafkaSupportConfig use BaseSupportConfig in a new way
3) PR in this repo to remove `getAnonymousEndpoint` and such from BaseSupportConfig.


