### PR TITLE
Constructors in ConfluentSubmitter for phone-home clients

### DIFF
--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -249,13 +249,13 @@ public abstract class BaseSupportConfig {
     return null;
   }
 
-  private String getEndpoint(boolean secure, String customerId, String endpointPath) {
+  public static String getEndpoint(boolean secure, String customerId, String endpointPath) {
     String base = secure ? CONFLUENT_PHONE_HOME_ENDPOINT_BASE_SECURE
                          : CONFLUENT_PHONE_HOME_ENDPOINT_BASE_INSECURE;
     return base + "/" + endpointPath + "/" + getEndpointSuffix(customerId);
   }
 
-  private String getEndpointSuffix(String customerId) {
+  private static String getEndpointSuffix(String customerId) {
     if (isAnonymousUser(customerId)) {
       return CONFLUENT_PHONE_HOME_ENDPOINT_SUFFIX_USER_ANON;
     } else if (isTestUser(customerId)) {

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/submitters/ConfluentSubmitter.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/submitters/ConfluentSubmitter.java
@@ -59,6 +59,37 @@ public class ConfluentSubmitter implements Submitter {
     return s == null || s.isEmpty();
   }
 
+  /**
+   * Constructor for phone-home clients which use ConfluentSubmitter directly instead of
+   * BaseMetricsReporter and, as a result, don't need PhoneHomeConfig.
+   * Sets customerId = "anonymous"
+   */
+  public ConfluentSubmitter(String componentId, ResponseHandler responseHandler) {
+    this(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT, componentId, responseHandler);
+  }
+
+  /**
+   * Also constructor for phone-home clients which use ConfluentSubmitter directly, but lets set
+   * customer ID.
+   * Common use-case is customerId = "anonymous" (BaseSupportConfig
+   * .CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT) for production code, and "c0"
+   * (BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT) for internal testing. E.g. if we don't
+   * want to include any internal testing data to aggregations and analysis we do on S3 data that
+   * the server stores.
+   * If customerID is "anonymous", then the endpoint path ends in "/anon", and if customerId is
+   * "c0", then the endpoint path ends in "/test". CustomerId is also included in the body of
+   * the phone-home ping.
+   */
+  public ConfluentSubmitter(
+      String customerId, String componentId, ResponseHandler responseHandler
+  ) {
+    this(customerId,
+         BaseSupportConfig.getEndpoint(false, customerId, componentId),
+         BaseSupportConfig.getEndpoint(true, customerId, componentId),
+         BaseSupportConfig.CONFLUENT_SUPPORT_PROXY_DEFAULT,
+         responseHandler);
+  }
+
   public ConfluentSubmitter(
       String customerId,
       String endpointHTTP,
@@ -151,6 +182,17 @@ public class ConfluentSubmitter implements Submitter {
 
   private boolean isInsecureEndpointEnabled() {
     return !endpointHTTP.isEmpty();
+  }
+
+  /**
+   * Getters for testing
+   */
+  String getEndpointHTTP() {
+    return endpointHTTP;
+  }
+
+  String getEndpointHTTPS() {
+    return endpointHTTPS;
   }
 
   private boolean submittedSuccessfully(int statusCode) {

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/submitters/ConfluentSubmitterTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/submitters/ConfluentSubmitterTest.java
@@ -14,6 +14,7 @@
 package io.confluent.support.metrics.submitters;
 
 
+import org.apache.http.HttpResponse;
 import org.junit.Test;
 
 
@@ -96,6 +97,47 @@ public class ConfluentSubmitterTest {
 
     // When/Then
     new ConfluentSubmitter(customerId, httpEndpoint, httpsEndpoint);
+  }
+
+  @Test
+  public void testValidArgumentsForPhoneHomeConstructorWithoutCustomerId() {
+    ConfluentSubmitter submitter = new ConfluentSubmitter("test-component", null);
+    assertThat(ConfluentSubmitter.isNullOrEmpty(submitter.getProxy()));
+    assertThat(submitter
+                   .getEndpointHTTP()
+                   .equals(BaseSupportConfig.getEndpoint(
+                       false,
+                       BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT,
+                       "test-component"))
+    );
+    assertThat(submitter
+                   .getEndpointHTTPS()
+                   .equals(BaseSupportConfig.getEndpoint(
+                       true,
+                       BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT,
+                       "test-component"))
+    );
+  }
+
+  @Test
+  public void testValidArgumentsForPhoneHomeConstructorWithCustomerId() {
+    final String customerId = BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT;
+    final ResponseHandler responseHandler = new ResponseHandler() {
+      @Override
+      public void handle(HttpResponse response) {
+        //
+      }
+    };
+
+    ConfluentSubmitter submitter =
+        new ConfluentSubmitter(customerId, "test-component", responseHandler);
+    assertThat(ConfluentSubmitter.isNullOrEmpty(submitter.getProxy()));
+    assertThat(submitter.getEndpointHTTP()
+                   .equals(BaseSupportConfig.getEndpoint(false, customerId, "test-component"))
+    );
+    assertThat(submitter.getEndpointHTTPS()
+                   .equals(BaseSupportConfig.getEndpoint(true, customerId, "test-component"))
+    );
   }
 
   @Test


### PR DESCRIPTION
@norwood instead of using PhoneHomeConfig as I suggested in your PR, you can now construct ConfluentSubmitter: ` new ConfluentSubmitter("control-center", your_response_handler)`. I added one more constructor that you can use (or maybe later) if you want to test C3 phone-home end-to-end but don't want to pollute metrics that server would write to C3. The way that proactive support does system test is by using "test" endpoint (in your case, use ` new ConfluentSubmitter(BaseSupportConfig.CONFLUENT_SUPPORT_TEST_ID_DEFAULT, "control-center", your_response_handler)` and the server would write those metrics to S3 but in a different directory. 