### PR TITLE
PSM-53: Accept new customer ID format

### DIFF
--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -118,6 +118,9 @@ public abstract class BaseSupportConfig {
 
 
   private static final Pattern customerPattern = Pattern.compile("c\\d{1,30}");
+  private static final Pattern newCustomerPattern = Pattern.compile(
+      "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+  );
 
   public Properties getProperties() {
     return properties;
@@ -300,7 +303,9 @@ public abstract class BaseSupportConfig {
    * @return True if the value matches the pattern of Confluent's internal customer ids.
    */
   public static boolean isConfluentCustomer(String customerId) {
-    return customerId != null && customerPattern.matcher(customerId.toLowerCase()).matches();
+    return customerId != null
+           && (customerPattern.matcher(customerId.toLowerCase()).matches()
+               || newCustomerPattern.matcher(customerId).matches());
   }
 
   /**

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -118,8 +118,11 @@ public abstract class BaseSupportConfig {
 
 
   private static final Pattern customerPattern = Pattern.compile("c\\d{1,30}");
-  private static final Pattern newCustomerPattern = Pattern.compile(
-      "[a-zA-Z0-9]{15}|[a-zA-Z0-9]{18}"
+  private static final Pattern newCustomerCaseSensitivePattern = Pattern.compile(
+      "[a-zA-Z0-9]{15}"
+  );
+  private static final Pattern newCustomerCaseInsensitivePattern = Pattern.compile(
+      "[a-zA-Z0-9]{18}"
   );
 
   public Properties getProperties() {
@@ -305,7 +308,8 @@ public abstract class BaseSupportConfig {
   public static boolean isConfluentCustomer(String customerId) {
     return customerId != null
            && (customerPattern.matcher(customerId.toLowerCase()).matches()
-               || newCustomerPattern.matcher(customerId).matches());
+               || newCustomerCaseInsensitivePattern.matcher(customerId).matches()
+               || newCustomerCaseSensitivePattern.matcher(customerId).matches());
   }
 
   /**
@@ -314,6 +318,17 @@ public abstract class BaseSupportConfig {
    */
   public static boolean isSyntacticallyCorrectCustomerId(String customerId) {
     return isAnonymousUser(customerId) || isConfluentCustomer(customerId);
+  }
+
+  /**
+   * The 15-character alpha-numeric customer IDs are case-sensitive, others are case-insensitive.
+   * The old-style customer ID "c\\d{1,30}" maybe look the same as a 15-character alpha-numeric ID,
+   * if its length is also 15 characters. In that case, this method will return true.
+   * @param customerId The value of "confluent.support.customer.id".
+   * @return true if customer Id is case sensitive
+   */
+  public static boolean isCaseSensitiveCustomerId(String customerId) {
+    return newCustomerCaseSensitivePattern.matcher(customerId).matches();
   }
 
   public String getCustomerId() {

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -119,7 +119,7 @@ public abstract class BaseSupportConfig {
 
   private static final Pattern customerPattern = Pattern.compile("c\\d{1,30}");
   private static final Pattern newCustomerPattern = Pattern.compile(
-      "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+      "[a-zA-Z0-9]{15}|[a-zA-Z0-9]{18}"
   );
 
   public Properties getProperties() {

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
@@ -39,6 +39,15 @@ public class BaseSupportConfigTest {
   }
 
   @Test
+  public void testValidNewCustomer() {
+    for (String validId : CustomerIdExamples.validNewCustomerIds) {
+      assertThat(validId + " is an invalid new customer identifier",
+                 BaseSupportConfig.isConfluentCustomer(validId), is(true)
+      );
+    }
+  }
+
+  @Test
   public void testInvalidCustomer() {
     String[]
         invalidIds =

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/BaseSupportConfigTest.java
@@ -40,7 +40,13 @@ public class BaseSupportConfigTest {
 
   @Test
   public void testValidNewCustomer() {
-    for (String validId : CustomerIdExamples.validNewCustomerIds) {
+    String[]
+        validNewCustomerIds =
+        ObjectArrays.concat(CustomerIdExamples.validCaseSensitiveNewCustomerIds,
+                            CustomerIdExamples.validCaseInsensitiveNewCustomerIds,
+                            String.class
+        );
+    for (String validId : validNewCustomerIds) {
       assertThat(validId + " is an invalid new customer identifier",
                  BaseSupportConfig.isConfluentCustomer(validId), is(true)
       );
@@ -99,6 +105,11 @@ public class BaseSupportConfigTest {
           BaseSupportConfig.isSyntacticallyCorrectCustomerId(validValue),
           is(true)
       );
+      // old customer Ids are all case-insensitive
+      assertThat(validValue + " is case-sensitive customer ID.",
+                 BaseSupportConfig.isCaseSensitiveCustomerId(validValue),
+                 is(false)
+      );
     }
   }
 
@@ -118,6 +129,25 @@ public class BaseSupportConfigTest {
     }
   }
 
+  @Test
+  public void testCaseInsensitiveNewCustomerIds() {
+    for (String validValue : CustomerIdExamples.validCaseInsensitiveNewCustomerIds) {
+      assertThat(validValue + " is case-sensitive customer ID.",
+                 BaseSupportConfig.isCaseSensitiveCustomerId(validValue),
+                 is(false)
+      );
+    }
+  }
+
+  @Test
+  public void testCaseSensitiveNewCustomerIds() {
+    for (String validValue : CustomerIdExamples.validCaseSensitiveNewCustomerIds) {
+      assertThat(validValue + " is case-insensitive customer ID.",
+                 BaseSupportConfig.isCaseSensitiveCustomerId(validValue),
+                 is(true)
+      );
+    }
+  }
 
   @Test
   public void proactiveSupportConfigIsValidKafkaConfig() throws IOException {

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
@@ -21,9 +21,35 @@ public class CustomerIdExamples {
       "c00000", "c12345", "c99999", "c123456789", "c123456789012345678901234567890",
   };
 
+  public static final String[] validNewCustomerIds = {
+      "Ca765292-ED42-11AE-BACD-00AA0057B223",
+      "4d36e96e-e345-31ce-bfc1-08003be19318",
+      "4d36E96e-e345-31cE-bfc1-08003bE19318",
+      "adccccbe-eaaa-ffcf-bfce-adaacbEbffff",
+      "40360960-0345-3100-0001-080030019318",
+      "ADCCCCBE-EAAA-FFCF-BFCE-ADAABBBFFFAA",
+      "ADccCCBE-EAAA-FfCF-BFCE-ADAAbbbFFFAA",
+      "00000000-0000-0000-0000-000000000000",
+      "00000000-0000-0000-0000-000000000001"
+  };
+
   // These invalid customer ids should not include valid anonymous user IDs.
   public static final String[] invalidCustomerIds = {
-      "0c000", "0000C", null, "", "c", "C", "Hello", "World", "1", "12", "123", "1234", "12345"
+      "0c000", "0000C", null, "", "c", "C", "Hello", "World", "1", "12", "123", "1234", "12345",
+      "00000000-0000-0000-0000-00000000000",
+      "0000000-0000-0000-0000-000000000000",
+      "00000000-000-0000-0000-000000000000",
+      "00000000-0000-000-0000-000000000000",
+      "00000000-0000-0000-000-000000000000",
+      "HDCCCCBE-EAAA-FFCF-BFCE-ADAABBBFFFAA",
+      "ADCCCCBE-EAAA-FFCF-BFCE-ADAABBBFFFA*",
+      "ADCCCCBE-EAAA-FFCF-BFCE-ADAABBBFFFA!",
+      "ADCCCCBE-EAAA-FFCF-BFCE-ADAABBBFFFA%",
+      "Ca765292-ED42-11AE-BKCD-00AA0057B223",
+      "Ca765292-ED42-11AE-BACD-00AA005IB223",
+      "Ca765292-ED42-11AE-BACD-00AA0057P223",
+      "Ca765292-ED42-11AE-BACD-00AA0057p223",
+      "xxxxxxxx-ED42-11AE-BACD-00AA0057B223"
   };
 
   public static final String[] validAnonymousIds = {"anonymous", "ANONYMOUS", "anonyMOUS"};

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
@@ -22,34 +22,33 @@ public class CustomerIdExamples {
   };
 
   public static final String[] validNewCustomerIds = {
-      "Ca765292-ED42-11AE-BACD-00AA0057B223",
-      "4d36e96e-e345-31ce-bfc1-08003be19318",
-      "4d36E96e-e345-31cE-bfc1-08003bE19318",
-      "adccccbe-eaaa-ffcf-bfce-adaacbEbffff",
-      "40360960-0345-3100-0001-080030019318",
-      "ADCCCCBE-EAAA-FFCF-BFCE-ADAABBBFFFAA",
-      "ADccCCBE-EAAA-FfCF-BFCE-ADAAbbbFFFAA",
-      "00000000-0000-0000-0000-000000000000",
-      "00000000-0000-0000-0000-000000000001"
+      "5003001200D8cyJ",
+      "abbcaabcaaDwcyJ",
+      "abbcaabcaadwcyj",
+      "AGGQAAFLSSDWPYJ",
+      "123456789012345",
+      "123456789012345123",
+      "123456789012345avc",
+      "5003001200D8cyJaaa",
+      "5003001200D8cyJ123",
+      "abbcaabcaadwcyjsss",
+      "AGGQAAFLSSDWPYJTTT",
   };
 
   // These invalid customer ids should not include valid anonymous user IDs.
   public static final String[] invalidCustomerIds = {
       "0c000", "0000C", null, "", "c", "C", "Hello", "World", "1", "12", "123", "1234", "12345",
-      "00000000-0000-0000-0000-00000000000",
-      "0000000-0000-0000-0000-000000000000",
-      "00000000-000-0000-0000-000000000000",
-      "00000000-0000-000-0000-000000000000",
-      "00000000-0000-0000-000-000000000000",
-      "HDCCCCBE-EAAA-FFCF-BFCE-ADAABBBFFFAA",
-      "ADCCCCBE-EAAA-FFCF-BFCE-ADAABBBFFFA*",
-      "ADCCCCBE-EAAA-FFCF-BFCE-ADAABBBFFFA!",
-      "ADCCCCBE-EAAA-FFCF-BFCE-ADAABBBFFFA%",
-      "Ca765292-ED42-11AE-BKCD-00AA0057B223",
-      "Ca765292-ED42-11AE-BACD-00AA005IB223",
-      "Ca765292-ED42-11AE-BACD-00AA0057P223",
-      "Ca765292-ED42-11AE-BACD-00AA0057p223",
-      "xxxxxxxx-ED42-11AE-BACD-00AA0057B223"
+      "5003001200D8cy",
+      "abbcaabcaaDwcyJa",
+      "abbcaabcaadwc*j",
+      "AGGQAAFLSSD^PYJ",
+      "123456789$12345",
+      "12345678901234512",
+      "123456789012345avca",
+      "5003001200D8cyJaaa88",
+      "5003001200D8cyJ1@3",
+      "abbcaabcaadwcyj!ss",
+      "AGGQAAFLSSDWPYJ_TT",
   };
 
   public static final String[] validAnonymousIds = {"anonymous", "ANONYMOUS", "anonyMOUS"};

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/utils/CustomerIdExamples.java
@@ -21,18 +21,25 @@ public class CustomerIdExamples {
       "c00000", "c12345", "c99999", "c123456789", "c123456789012345678901234567890",
   };
 
-  public static final String[] validNewCustomerIds = {
+  public static final String[] validCaseSensitiveNewCustomerIds = {
       "5003001200D8cyJ",
       "abbcaabcaaDwcyJ",
       "abbcaabcaadwcyj",
+      "abbcaAbcAadwcyj",
       "AGGQAAFLSSDWPYJ",
+      "AGGQAAfLSSDWpYJ",
       "123456789012345",
+      "c23456789012345",
+      "C23456789012345"
+  };
+
+  public static final String[] validCaseInsensitiveNewCustomerIds = {
       "123456789012345123",
       "123456789012345avc",
       "5003001200D8cyJaaa",
       "5003001200D8cyJ123",
       "abbcaabcaadwcyjsss",
-      "AGGQAAFLSSDWPYJTTT",
+      "AGGQAAFLSSDWPYJTTT"
   };
 
   // These invalid customer ids should not include valid anonymous user IDs.


### PR DESCRIPTION
Accept customer IDs that are either 15-character or 18-character alphanumeric strings (Unique Record IDs in Salesforce). But also allow customer IDs in the old format.

