### PR TITLE
PSM-61: createAndVerifyTopic waits for leader election

### DIFF
--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/KafkaUtilities.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/KafkaUtilities.java
@@ -305,7 +305,7 @@ public class KafkaUtilities {
     long now;
     while ((now = Time.SYSTEM.milliseconds()) < startMs + timeout) {
       scala.Option<Object> leaderOpt = zkUtils.getLeaderForPartition(topic, partition);
-      if (leaderOpt.isDefined()) {
+      if (leaderOpt.isDefined() && ((int) leaderOpt.get() >= 0)) {
         return;
       }
       Thread.sleep(Math.min(startMs + timeout - now, 100L));

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/KafkaUtilities.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/KafkaUtilities.java
@@ -126,7 +126,9 @@ public class KafkaUtilities {
   }
 
   /**
-   * Creates a topic in Kafka, if it is not already there, and verifies that it is properly created
+   * Creates a topic in Kafka, if it is not already there, and verifies that it is properly
+   * created. After the method returns (true), it guarantees that leaders are elected for every
+   * new topic partition, but does not guarantee that all metadata is propagated to all the brokers.
    *
    * @param partitions  Desired number of partitions
    * @param replication Desired number of replicas
@@ -178,7 +180,7 @@ public class KafkaUtilities {
       log.info("Attempting to create topic {} with {} replicas, assuming {} total brokers",
           topic, actualReplication, brokerList.size());
       AdminUtils.createTopic(zkUtils, topic, partitions, actualReplication, metricsTopicProps, Disabled$.MODULE$);
-      // wait until metadata is propagated to brokers
+      // wait until leader is elected for every topic partition we created
       for (int part = 0; part < partitions; ++part) {
         waitUntilLeaderIsElected(zkUtils, topic, part, 30000L);
       }

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/common/kafka/KafkaUtilitiesTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/common/kafka/KafkaUtilitiesTest.java
@@ -225,7 +225,6 @@ public class KafkaUtilitiesTest {
     }
   }
 
-
   @Test
   public void verifySupportTopicThrowsIAEWhenZkUtilsIsNull() {
     // Given
@@ -384,6 +383,22 @@ public class KafkaUtilitiesTest {
 
     // Cleanup
     cluster.stopCluster();
+  }
+
+  @Test
+  public void leaderIsElectedAfterCreateTopicReturns() {
+    // Given
+    KafkaUtilities kUtil = new KafkaUtilities();
+    EmbeddedKafkaCluster cluster = new EmbeddedKafkaCluster();
+    int numBrokers = 3;
+    cluster.startCluster(numBrokers);
+    KafkaServer broker = cluster.getBroker(0);
+    ZkUtils zkUtils = broker.zkUtils();
+    int replication = numBrokers;
+
+    assertThat(kUtil.createAndVerifyTopic(zkUtils, anyTopic, anyPartitions, replication,
+                                          oneYearRetention)).isTrue();
+    assertThat(zkUtils.getLeaderForPartition(anyTopic, 0).isDefined()).isTrue();
   }
 
 }


### PR DESCRIPTION
Currently, KafkaUtilities.createAndVerifyTopic creates topic with ZK but does not wait for metadata to be propagated. The metrics collector code seems to be designed such that it's ok to lose some metrics data if topic is not ready yet. Since submitting metrics is done in a separate thread, making KafkaUtilities.createAndVerifyTopic return *after* leader is elected for all partitions is better since we will not lose the first set of metrics.

The motivation for this change is build failures in support-metrics-fullcollector branch, because the test creates topic using KafkaUtilities.createAndVerifyTopic and sleeps 1 sec before producing to it. The fix is this PR + https://github.com/confluentinc/support-metrics-fullcollector/pull/32 (which checks the output of createAndVerifyTopic() and fails sooner/with better error message is case of create topic failure).
