### PR TITLE
PSM-64(part1): Move validation of KSQL module type to common

### DIFF
--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/validate/KSqlValidModuleType.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/validate/KSqlValidModuleType.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.validate;
+
+/**
+ * Maintains current and previous valid types of KsqlModuleType
+ */
+public enum KSqlValidModuleType {
+  LOCAL_CLI,
+  REMOTE_CLI,
+  CLI,
+  EMBEDDED,
+  SERVER;
+}

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/validate/MetricsValidation.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/validate/MetricsValidation.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.support.metrics.validate;
+
+/**
+ * Utility methods to verify metrics fields for various components
+ */
+public class MetricsValidation {
+
+  public static boolean isValidKsqlModuleType(String moduleType) {
+    for (KSqlValidModuleType type: KSqlValidModuleType.values()) {
+      if (moduleType.equals(type.name())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/support-metrics-common/src/test/java/io/confluent/support/metrics/validate/MetricsValidationTest.java
+++ b/support-metrics-common/src/test/java/io/confluent/support/metrics/validate/MetricsValidationTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.confluent.support.metrics.validate;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class MetricsValidationTest {
+
+  @Test
+  public void testValidKsqlDeploymentMode() {
+    ImmutableList<String> validDeploymentModes = ImmutableList.of(
+        "LOCAL_CLI", "REMOTE_CLI", "SERVER", "EMBEDDED", "CLI"
+    );
+
+    for (String mode: validDeploymentModes) {
+      assertTrue("Expected KSQL deployment mode '" + mode + "' to be valid",
+                 MetricsValidation.isValidKsqlModuleType(mode));
+    }
+  }
+
+  @Test
+  public void testInvalidKsqlDeploymentMode() {
+    ImmutableList<String> invalidDeploymentModes = ImmutableList.of(
+        "local_CLI", "REMOTECLI", "servER", "random", "ANOTHER_CLI"
+    );
+
+    for (String mode: invalidDeploymentModes) {
+      assertFalse("Expected KSQL deployment mode '" + mode + "' to be invalid",
+                 MetricsValidation.isValidKsqlModuleType(mode));
+    }
+  }
+
+}


### PR DESCRIPTION
The goal is to let KsqlModuleType to evolve without impacting phone-home server. Phone-home server currently validates KSQL beacon pings using KsqlModuleType.values(). We want to remove some fields from KsqlModuleType, but let the server accept pings from previous and current versions. 

This PR adds MetricsValidation. isValidKsqlModuleType() method to be used by the server to validate KSQL pings. 