### PR TITLE
CP-535(part 2): Removed duplicate avro-maven-plugin from pom

### DIFF
--- a/support-metrics-common/pom.xml
+++ b/support-metrics-common/pom.xml
@@ -157,24 +157,6 @@
           <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.avro</groupId>
-        <artifactId>avro-maven-plugin</artifactId>
-        <version>${avro.version}</version>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>schema</goal>
-            </goals>
-            <configuration>
-              <sourceDirectory>${project.basedir}/src/main/avro/</sourceDirectory>
-              <testSourceDirectory>${project.basedir}/src/test/</testSourceDirectory>
-              <stringType>String</stringType>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This should have been merged to 4.1.x originally but merged to master (https://github.com/confluentinc/support-metrics-common/pull/38), so making a separate PR for the same fix.