### PR TITLE
Drop log level to info when no customer id is configured

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <assertj.version>2.2.0</assertj.version>
-    <mockito.version>2.0.31-beta</mockito.version>
+    <mock-server.version>3.10.4</mock-server.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven-assembly.version>2.6</maven-assembly.version>
     <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>

--- a/support-metrics-common/pom.xml
+++ b/support-metrics-common/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
+      <version>${mockito-all.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-netty</artifactId>
-      <version>3.10.4</version>
+      <version>${mock-server.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -103,7 +103,7 @@
     <dependency>
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-client-java</artifactId>
-      <version>3.10.4</version>
+      <version>${mock-server.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/BaseSupportConfig.java
@@ -339,7 +339,7 @@ public abstract class BaseSupportConfig {
     String fallbackId = BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_DEFAULT;
     String id = props.getProperty(BaseSupportConfig.CONFLUENT_SUPPORT_CUSTOMER_ID_CONFIG);
     if (id == null || id.isEmpty()) {
-      log.error("No customer ID configured -- falling back to id '{}'", fallbackId);
+      log.info("No customer ID configured -- falling back to id '{}'", fallbackId);
       id = fallbackId;
     }
     if (!isSyntacticallyCorrectCustomerId(id)) {


### PR DESCRIPTION
See https://github.com/confluentinc/ksql/issues/1205

Users find it concerning when this is reported as an error. Better to just drop the level to info since the message that no customer id is configured is really informational. 

This PR also fixes the mockito versions. Without those fixes, the tests cannot run on jdk10, causing the PR branch builder to fail.