### PR TITLE
Set version of maven-site and maven-project-info-reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
     <mockito.version>2.0.31-beta</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven-assembly.version>2.6</maven-assembly.version>
+    <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+    <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
     <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
   </properties>
 
@@ -58,6 +60,23 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${maven-assembly.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${maven-site-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>${maven-project-info-reports-plugin.version}</version>
+          <configuration>
+            <!--
+            Disable dependency locations for latest maven-plugin-info-reports to eliminate blacklisting
+            warnings: "The repository url '...' is invalid - Repository '...' will be blacklisted."
+            -->
+            <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
4.0.x branch does not use common as a parent POM, so the same changes that has been applied to common to fix maven-site incompatibilities need to be applied here.