### PR TITLE
MINOR: Set interrupt flag when catching InterruptedException

### DIFF
--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/KafkaUtilities.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/common/kafka/KafkaUtilities.java
@@ -210,6 +210,7 @@ public class KafkaUtilities {
       log.error("Timed out waiting for leader to be elected after creating topic: {}",
                 toe.getMessage());
     } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
       topicCreated = false;
       log.error("Interrupted the wait for leader to be elected after creating topic={}", topic);
     } catch (Exception e) {

--- a/support-metrics-common/src/main/java/io/confluent/support/metrics/submitters/KafkaSubmitter.java
+++ b/support-metrics-common/src/main/java/io/confluent/support/metrics/submitters/KafkaSubmitter.java
@@ -91,6 +91,7 @@ public class KafkaSubmitter implements Submitter {
         }
         log.info("Successfully submitted metrics to Kafka topic {}", topic);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         log.error(
             "Failed to submit metrics to Kafka topic {} (canceled request): {}",
             topic,


### PR DESCRIPTION
This patch sets the interrupted flag in places where we are catching InterruptedException. Since we rely on the interrupted to determine when to shutdown, it is necessary that we don't swallow this Exception anywhere in the code.

Signed-off-by: Arjun Satish <arjun@confluent.io>