### PR TITLE
PSM-70: Upgrade commons-validator to 1.5.1 to upgrade transitive dep …

### DIFF
--- a/support-metrics-common/pom.xml
+++ b/support-metrics-common/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
-      <version>1.4.1</version>
+      <version>1.5.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Upgrade commons-validator to 1.5.1 to upgrade transitive dependency commons-collections-3.2.1 jar to 3.2.2

