### PR TITLE
CPKAFKA-1929: Remove hard-coded kafka version in assembly/package.

### DIFF
--- a/package/src/assembly/package.xml
+++ b/package/src/assembly/package.xml
@@ -33,7 +33,7 @@
       <scope>runtime</scope>
       <useTransitiveFiltering>true</useTransitiveFiltering>
       <excludes>
-        <exclude>org.apache.kafka:kafka_2.11</exclude>
+        <exclude>org.apache.kafka:kafka_${kafka.scala.version}</exclude>
         <exclude>org.apache.kafka:kafka_clients</exclude>
         <!-- jline for some reason has a compile dependency on junit which is getting pulled in here -->
         <exclude>junit:junit</exclude>


### PR DESCRIPTION
Relates to failures encountered when packaging against Scala 2.12, surfaced via https://github.com/confluentinc/packaging/pull/387.

I wasn't sure on which branch to base this, since it can be applied to the original packaging and any greater version c/o pint, yet realistically it seems the issue would only surface on later releases built against 2.12.