### PR TITLE
Backport: METRICS-2812: Upgrade HttpClient to 4.5.13

### DIFF
--- a/support-metrics-common/pom.xml
+++ b/support-metrics-common/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
+      <version>4.5.13</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Back port https://github.com/confluentinc/support-metrics-common/pull/54